### PR TITLE
Alter logic in interval timer

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -49,20 +49,14 @@ const shuffle = array => {
 
 //Timer function
 const timer = () => {
-    
     clock = setInterval(function() {
-        //Check if seconds are equal to 50 and set to -1
-        if(secs === 59) {
-            secs = -1; // Next increment will display as 0
-            //Add to minutes
-            mins ++;
-
-        }
-        //add to seconds and display in UI
         secs++;
+        if(secs === 60) {
+            secs = 0;
+            mins++;
+        }
         secDisplay.innerHTML = secs;
         minDisplay.innerHTML = mins;
-
     }, 1000);
 };
 


### PR DESCRIPTION
As function currently was, it would never show the time as 59 seconds. It would increment to 59, not show it, then jump straight to 0.